### PR TITLE
Neft and Buffs to Stimpak and Healing Powder

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1257,7 +1257,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	taste_description = "grossness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -1268,9 +1268,9 @@
 	..()
 
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-3*REM, 0)
-	M.adjustFireLoss(-3*REM, 0)
-	M.adjustOxyLoss(-2*REM, 0)
+	M.adjustBruteLoss(-2.5*REM, 0)
+	M.adjustFireLoss(-2.5*REM, 0)
+	M.adjustOxyLoss(-2.5*REM, 0)
 	. = 1
 	..()
 
@@ -1281,7 +1281,7 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/M)


### PR DESCRIPTION
half the time on simpak to neft the longer time it is active I have made all damage heal only by 2.5 points emplace of 3

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

Description
Stimpak time in Mobs body is increase by reducing the used rate from 3 to 1.5 and healing powder is increased to 0.75 per tick but to reduce stimpak healing ability slightly all is reduced to 2.5 (or increase in oxylesses case) 

Motivation and Context
healing powder was way better than stimpaks because how little was used and was used many a time to bring legion member from crit to walking once more making most healing items useless as such stimpaks

 How Has This Been Tested?
No Tests have been made for far
## Screenshots (if appropriate):
